### PR TITLE
update readme to explain this repo's purpose

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,6 @@
 # kotlinx-browser
-Kotlin browser API
+This repo contains tools for downloading IDLs from web api specs, and converting
+those IDLs to kotlin. This repo is not the "source of truth" for the kotlinx.browser package.
+
+For now, browser APIs ship with the kotlin standard library:
+https://github.com/JetBrains/kotlin/tree/master/libraries/stdlib/js


### PR DESCRIPTION
Lots of people (including myself) were under the impression that this repo was the source of the kotlinx.browser part of the stdlib. However, that is not the case: https://kotlinlang.slack.com/archives/C0B8L3U69/p1620183844128600

This PR updates the readme to explain what this repo is, and direct people to the stdlib.