### PR TITLE
use @JsName("Object") for emulating JavaScript IDLs

### DIFF
--- a/generator/src/main/kotlin/dukat/common/convertToModel.kt
+++ b/generator/src/main/kotlin/dukat/common/convertToModel.kt
@@ -627,7 +627,7 @@ private class IdlFileConverter(
             annotations = mutableListOf(
                 AnnotationModel(
                     IdentifierEntity("JsName"),
-                    listOf(IdentifierEntity("null"))
+                    listOf(IdentifierEntity("Object"))
                 ),
                 suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
             ),

--- a/generator/src/main/kotlin/dukat/js/convertToModel.kt
+++ b/generator/src/main/kotlin/dukat/js/convertToModel.kt
@@ -593,7 +593,7 @@ private class IdlFileConverter(
             annotations = mutableListOf(
                 AnnotationModel(
                     IdentifierEntity("JsName"),
-                    listOf(IdentifierEntity("null"))
+                    listOf(IdentifierEntity("Object"))
                 ),
                 suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE"),
             ),

--- a/src/jsMain/kotlin/org.w3c/org.khronos.webgl.kt
+++ b/src/jsMain/kotlin/org.w3c/org.khronos.webgl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/jsMain/kotlin/org.w3c/org.w3c.css.masking.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.css.masking.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/jsMain/kotlin/org.w3c/org.w3c.dom.clipboard.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.dom.clipboard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/jsMain/kotlin/org.w3c/org.w3c.dom.css.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.dom.css.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/jsMain/kotlin/org.w3c/org.w3c.dom.encryptedmedia.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.dom.encryptedmedia.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -182,7 +182,7 @@ actual inline fun MediaEncryptedEventInit(initDataType: String?, initData: Array
 }
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface MediaKeysRequirement {
     actual companion object
@@ -195,7 +195,7 @@ actual inline val MediaKeysRequirement.Companion.OPTIONAL: MediaKeysRequirement 
 actual inline val MediaKeysRequirement.Companion.NOT_ALLOWED: MediaKeysRequirement get() = "not-allowed".asDynamic().unsafeCast<MediaKeysRequirement>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface MediaKeySessionType {
     actual companion object
@@ -206,7 +206,7 @@ actual inline val MediaKeySessionType.Companion.TEMPORARY: MediaKeySessionType g
 actual inline val MediaKeySessionType.Companion.PERSISTENT_LICENSE: MediaKeySessionType get() = "persistent-license".asDynamic().unsafeCast<MediaKeySessionType>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface MediaKeyStatus {
     actual companion object
@@ -227,7 +227,7 @@ actual inline val MediaKeyStatus.Companion.STATUS_PENDING: MediaKeyStatus get() 
 actual inline val MediaKeyStatus.Companion.INTERNAL_ERROR: MediaKeyStatus get() = "internal-error".asDynamic().unsafeCast<MediaKeyStatus>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface MediaKeyMessageType {
     actual companion object

--- a/src/jsMain/kotlin/org.w3c/org.w3c.dom.events.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.dom.events.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/jsMain/kotlin/org.w3c/org.w3c.dom.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.dom.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -6515,7 +6515,7 @@ actual external interface ImageBitmapSource
 actual external interface HTMLOrSVGScriptElement
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface DocumentReadyState {
     actual companion object
@@ -6528,7 +6528,7 @@ actual inline val DocumentReadyState.Companion.INTERACTIVE: DocumentReadyState g
 actual inline val DocumentReadyState.Companion.COMPLETE: DocumentReadyState get() = "complete".asDynamic().unsafeCast<DocumentReadyState>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface CanPlayTypeResult {
     actual companion object
@@ -6541,7 +6541,7 @@ actual inline val CanPlayTypeResult.Companion.MAYBE: CanPlayTypeResult get() = "
 actual inline val CanPlayTypeResult.Companion.PROBABLY: CanPlayTypeResult get() = "probably".asDynamic().unsafeCast<CanPlayTypeResult>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface TextTrackMode {
     actual companion object
@@ -6554,7 +6554,7 @@ actual inline val TextTrackMode.Companion.HIDDEN: TextTrackMode get() = "hidden"
 actual inline val TextTrackMode.Companion.SHOWING: TextTrackMode get() = "showing".asDynamic().unsafeCast<TextTrackMode>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface TextTrackKind {
     actual companion object
@@ -6571,7 +6571,7 @@ actual inline val TextTrackKind.Companion.CHAPTERS: TextTrackKind get() = "chapt
 actual inline val TextTrackKind.Companion.METADATA: TextTrackKind get() = "metadata".asDynamic().unsafeCast<TextTrackKind>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface SelectionMode {
     actual companion object
@@ -6586,7 +6586,7 @@ actual inline val SelectionMode.Companion.END: SelectionMode get() = "end".asDyn
 actual inline val SelectionMode.Companion.PRESERVE: SelectionMode get() = "preserve".asDynamic().unsafeCast<SelectionMode>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface CanvasFillRule {
     actual companion object
@@ -6597,7 +6597,7 @@ actual inline val CanvasFillRule.Companion.NONZERO: CanvasFillRule get() = "nonz
 actual inline val CanvasFillRule.Companion.EVENODD: CanvasFillRule get() = "evenodd".asDynamic().unsafeCast<CanvasFillRule>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface ImageSmoothingQuality {
     actual companion object
@@ -6610,7 +6610,7 @@ actual inline val ImageSmoothingQuality.Companion.MEDIUM: ImageSmoothingQuality 
 actual inline val ImageSmoothingQuality.Companion.HIGH: ImageSmoothingQuality get() = "high".asDynamic().unsafeCast<ImageSmoothingQuality>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface CanvasLineCap {
     actual companion object
@@ -6623,7 +6623,7 @@ actual inline val CanvasLineCap.Companion.ROUND: CanvasLineCap get() = "round".a
 actual inline val CanvasLineCap.Companion.SQUARE: CanvasLineCap get() = "square".asDynamic().unsafeCast<CanvasLineCap>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface CanvasLineJoin {
     actual companion object
@@ -6636,7 +6636,7 @@ actual inline val CanvasLineJoin.Companion.BEVEL: CanvasLineJoin get() = "bevel"
 actual inline val CanvasLineJoin.Companion.MITER: CanvasLineJoin get() = "miter".asDynamic().unsafeCast<CanvasLineJoin>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface CanvasTextAlign {
     actual companion object
@@ -6653,7 +6653,7 @@ actual inline val CanvasTextAlign.Companion.RIGHT: CanvasTextAlign get() = "righ
 actual inline val CanvasTextAlign.Companion.CENTER: CanvasTextAlign get() = "center".asDynamic().unsafeCast<CanvasTextAlign>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface CanvasTextBaseline {
     actual companion object
@@ -6672,7 +6672,7 @@ actual inline val CanvasTextBaseline.Companion.IDEOGRAPHIC: CanvasTextBaseline g
 actual inline val CanvasTextBaseline.Companion.BOTTOM: CanvasTextBaseline get() = "bottom".asDynamic().unsafeCast<CanvasTextBaseline>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface CanvasDirection {
     actual companion object
@@ -6685,7 +6685,7 @@ actual inline val CanvasDirection.Companion.RTL: CanvasDirection get() = "rtl".a
 actual inline val CanvasDirection.Companion.INHERIT: CanvasDirection get() = "inherit".asDynamic().unsafeCast<CanvasDirection>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface ScrollRestoration {
     actual companion object
@@ -6696,7 +6696,7 @@ actual inline val ScrollRestoration.Companion.AUTO: ScrollRestoration get() = "a
 actual inline val ScrollRestoration.Companion.MANUAL: ScrollRestoration get() = "manual".asDynamic().unsafeCast<ScrollRestoration>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface ImageOrientation {
     actual companion object
@@ -6707,7 +6707,7 @@ actual inline val ImageOrientation.Companion.NONE: ImageOrientation get() = "non
 actual inline val ImageOrientation.Companion.FLIPY: ImageOrientation get() = "flipY".asDynamic().unsafeCast<ImageOrientation>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface PremultiplyAlpha {
     actual companion object
@@ -6720,7 +6720,7 @@ actual inline val PremultiplyAlpha.Companion.PREMULTIPLY: PremultiplyAlpha get()
 actual inline val PremultiplyAlpha.Companion.DEFAULT: PremultiplyAlpha get() = "default".asDynamic().unsafeCast<PremultiplyAlpha>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface ColorSpaceConversion {
     actual companion object
@@ -6731,7 +6731,7 @@ actual inline val ColorSpaceConversion.Companion.NONE: ColorSpaceConversion get(
 actual inline val ColorSpaceConversion.Companion.DEFAULT: ColorSpaceConversion get() = "default".asDynamic().unsafeCast<ColorSpaceConversion>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface ResizeQuality {
     actual companion object
@@ -6746,7 +6746,7 @@ actual inline val ResizeQuality.Companion.MEDIUM: ResizeQuality get() = "medium"
 actual inline val ResizeQuality.Companion.HIGH: ResizeQuality get() = "high".asDynamic().unsafeCast<ResizeQuality>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface BinaryType {
     actual companion object
@@ -6757,7 +6757,7 @@ actual inline val BinaryType.Companion.BLOB: BinaryType get() = "blob".asDynamic
 actual inline val BinaryType.Companion.ARRAYBUFFER: BinaryType get() = "arraybuffer".asDynamic().unsafeCast<BinaryType>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface WorkerType {
     actual companion object
@@ -6768,7 +6768,7 @@ actual inline val WorkerType.Companion.CLASSIC: WorkerType get() = "classic".asD
 actual inline val WorkerType.Companion.MODULE: WorkerType get() = "module".asDynamic().unsafeCast<WorkerType>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface ShadowRootMode {
     actual companion object
@@ -6779,7 +6779,7 @@ actual inline val ShadowRootMode.Companion.OPEN: ShadowRootMode get() = "open".a
 actual inline val ShadowRootMode.Companion.CLOSED: ShadowRootMode get() = "closed".asDynamic().unsafeCast<ShadowRootMode>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface ScrollBehavior {
     actual companion object
@@ -6792,7 +6792,7 @@ actual inline val ScrollBehavior.Companion.INSTANT: ScrollBehavior get() = "inst
 actual inline val ScrollBehavior.Companion.SMOOTH: ScrollBehavior get() = "smooth".asDynamic().unsafeCast<ScrollBehavior>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface ScrollLogicalPosition {
     actual companion object
@@ -6807,7 +6807,7 @@ actual inline val ScrollLogicalPosition.Companion.END: ScrollLogicalPosition get
 actual inline val ScrollLogicalPosition.Companion.NEAREST: ScrollLogicalPosition get() = "nearest".asDynamic().unsafeCast<ScrollLogicalPosition>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface CSSBoxType {
     actual companion object

--- a/src/jsMain/kotlin/org.w3c/org.w3c.dom.mediacapture.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.dom.mediacapture.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -666,7 +666,7 @@ actual inline fun Constraints(advanced: Array<ConstraintSet>?): Constraints {
 }
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface MediaStreamTrackState {
     actual companion object
@@ -677,7 +677,7 @@ actual inline val MediaStreamTrackState.Companion.LIVE: MediaStreamTrackState ge
 actual inline val MediaStreamTrackState.Companion.ENDED: MediaStreamTrackState get() = "ended".asDynamic().unsafeCast<MediaStreamTrackState>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface VideoFacingModeEnum {
     actual companion object
@@ -692,7 +692,7 @@ actual inline val VideoFacingModeEnum.Companion.LEFT: VideoFacingModeEnum get() 
 actual inline val VideoFacingModeEnum.Companion.RIGHT: VideoFacingModeEnum get() = "right".asDynamic().unsafeCast<VideoFacingModeEnum>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface VideoResizeModeEnum {
     actual companion object
@@ -703,7 +703,7 @@ actual inline val VideoResizeModeEnum.Companion.NONE: VideoResizeModeEnum get() 
 actual inline val VideoResizeModeEnum.Companion.CROP_AND_SCALE: VideoResizeModeEnum get() = "crop-and-scale".asDynamic().unsafeCast<VideoResizeModeEnum>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface MediaDeviceKind {
     actual companion object

--- a/src/jsMain/kotlin/org.w3c/org.w3c.dom.mediasource.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.dom.mediasource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -73,7 +73,7 @@ actual external abstract class SourceBufferList : EventTarget {
 actual inline operator fun SourceBufferList.get(index: Int): SourceBuffer? = asDynamic()[index]
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface ReadyState {
     actual companion object
@@ -86,7 +86,7 @@ actual inline val ReadyState.Companion.OPEN: ReadyState get() = "open".asDynamic
 actual inline val ReadyState.Companion.ENDED: ReadyState get() = "ended".asDynamic().unsafeCast<ReadyState>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface EndOfStreamError {
     actual companion object
@@ -97,7 +97,7 @@ actual inline val EndOfStreamError.Companion.NETWORK: EndOfStreamError get() = "
 actual inline val EndOfStreamError.Companion.DECODE: EndOfStreamError get() = "decode".asDynamic().unsafeCast<EndOfStreamError>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface AppendMode {
     actual companion object

--- a/src/jsMain/kotlin/org.w3c/org.w3c.dom.parsing.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.dom.parsing.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/jsMain/kotlin/org.w3c/org.w3c.dom.pointerevents.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.dom.pointerevents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/jsMain/kotlin/org.w3c/org.w3c.dom.svg.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.dom.svg.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/jsMain/kotlin/org.w3c/org.w3c.dom.url.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.dom.url.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/jsMain/kotlin/org.w3c/org.w3c.fetch.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.fetch.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -171,7 +171,7 @@ actual inline fun ResponseInit(status: Short?, statusText: String?, headers: dyn
 }
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface RequestType {
     actual companion object
@@ -194,7 +194,7 @@ actual inline val RequestType.Companion.TRACK: RequestType get() = "track".asDyn
 actual inline val RequestType.Companion.VIDEO: RequestType get() = "video".asDynamic().unsafeCast<RequestType>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface RequestDestination {
     actual companion object
@@ -231,7 +231,7 @@ actual inline val RequestDestination.Companion.WORKER: RequestDestination get() 
 actual inline val RequestDestination.Companion.XSLT: RequestDestination get() = "xslt".asDynamic().unsafeCast<RequestDestination>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface RequestMode {
     actual companion object
@@ -246,7 +246,7 @@ actual inline val RequestMode.Companion.NO_CORS: RequestMode get() = "no-cors".a
 actual inline val RequestMode.Companion.CORS: RequestMode get() = "cors".asDynamic().unsafeCast<RequestMode>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface RequestCredentials {
     actual companion object
@@ -259,7 +259,7 @@ actual inline val RequestCredentials.Companion.SAME_ORIGIN: RequestCredentials g
 actual inline val RequestCredentials.Companion.INCLUDE: RequestCredentials get() = "include".asDynamic().unsafeCast<RequestCredentials>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface RequestCache {
     actual companion object
@@ -278,7 +278,7 @@ actual inline val RequestCache.Companion.FORCE_CACHE: RequestCache get() = "forc
 actual inline val RequestCache.Companion.ONLY_IF_CACHED: RequestCache get() = "only-if-cached".asDynamic().unsafeCast<RequestCache>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface RequestRedirect {
     actual companion object
@@ -291,7 +291,7 @@ actual inline val RequestRedirect.Companion.ERROR: RequestRedirect get() = "erro
 actual inline val RequestRedirect.Companion.MANUAL: RequestRedirect get() = "manual".asDynamic().unsafeCast<RequestRedirect>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface ResponseType {
     actual companion object

--- a/src/jsMain/kotlin/org.w3c/org.w3c.files.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.files.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/jsMain/kotlin/org.w3c/org.w3c.notifications.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.notifications.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -192,7 +192,7 @@ actual inline fun NotificationEventInit(notification: Notification?, action: Str
 }
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface NotificationPermission {
     actual companion object
@@ -205,7 +205,7 @@ actual inline val NotificationPermission.Companion.DENIED: NotificationPermissio
 actual inline val NotificationPermission.Companion.GRANTED: NotificationPermission get() = "granted".asDynamic().unsafeCast<NotificationPermission>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface NotificationDirection {
     actual companion object

--- a/src/jsMain/kotlin/org.w3c/org.w3c.performance.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.performance.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/jsMain/kotlin/org.w3c/org.w3c.workers.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.workers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -494,7 +494,7 @@ actual external interface UnionMessagePortOrServiceWorker
 actual external interface UnionClientOrMessagePortOrServiceWorker
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface ServiceWorkerState {
     actual companion object
@@ -511,7 +511,7 @@ actual inline val ServiceWorkerState.Companion.ACTIVATED: ServiceWorkerState get
 actual inline val ServiceWorkerState.Companion.REDUNDANT: ServiceWorkerState get() = "redundant".asDynamic().unsafeCast<ServiceWorkerState>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface FrameType {
     actual companion object
@@ -526,7 +526,7 @@ actual inline val FrameType.Companion.NESTED: FrameType get() = "nested".asDynam
 actual inline val FrameType.Companion.NONE: FrameType get() = "none".asDynamic().unsafeCast<FrameType>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface ClientType {
     actual companion object

--- a/src/jsMain/kotlin/org.w3c/org.w3c.xhr.kt
+++ b/src/jsMain/kotlin/org.w3c/org.w3c.xhr.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -123,7 +123,7 @@ actual inline fun ProgressEventInit(lengthComputable: Boolean?, loaded: Number?,
 }
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 actual external interface XMLHttpRequestResponseType {
     actual companion object

--- a/src/wasmJsMain/kotlin/org.w3c/org.khronos.webgl.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.khronos.webgl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.css.masking.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.css.masking.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.clipboard.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.clipboard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.css.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.css.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.encryptedmedia.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.encryptedmedia.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -148,7 +148,7 @@ public actual external interface MediaEncryptedEventInit : EventInit, JsAny {
 public actual fun MediaEncryptedEventInit(initDataType: String?, initData: ArrayBuffer?, bubbles: Boolean?, cancelable: Boolean?, composed: Boolean?): MediaEncryptedEventInit = js("({ initDataType: initDataType, initData: initData, bubbles: bubbles, cancelable: cancelable, composed: composed })")
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface MediaKeysRequirement : JsAny {
     actual companion object
@@ -161,7 +161,7 @@ public actual inline val MediaKeysRequirement.Companion.OPTIONAL: MediaKeysRequi
 public actual inline val MediaKeysRequirement.Companion.NOT_ALLOWED: MediaKeysRequirement get() = "not-allowed".toJsString().unsafeCast<MediaKeysRequirement>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface MediaKeySessionType : JsAny {
     actual companion object
@@ -172,7 +172,7 @@ public actual inline val MediaKeySessionType.Companion.TEMPORARY: MediaKeySessio
 public actual inline val MediaKeySessionType.Companion.PERSISTENT_LICENSE: MediaKeySessionType get() = "persistent-license".toJsString().unsafeCast<MediaKeySessionType>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface MediaKeyStatus : JsAny {
     actual companion object
@@ -193,7 +193,7 @@ public actual inline val MediaKeyStatus.Companion.STATUS_PENDING: MediaKeyStatus
 public actual inline val MediaKeyStatus.Companion.INTERNAL_ERROR: MediaKeyStatus get() = "internal-error".toJsString().unsafeCast<MediaKeyStatus>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface MediaKeyMessageType : JsAny {
     actual companion object

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.events.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.events.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -6251,7 +6251,7 @@ public actual external interface ImageBitmapSource
 public actual external interface HTMLOrSVGScriptElement
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface DocumentReadyState : JsAny {
     actual companion object
@@ -6264,7 +6264,7 @@ public actual inline val DocumentReadyState.Companion.INTERACTIVE: DocumentReady
 public actual inline val DocumentReadyState.Companion.COMPLETE: DocumentReadyState get() = "complete".toJsString().unsafeCast<DocumentReadyState>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface CanPlayTypeResult : JsAny {
     actual companion object
@@ -6277,7 +6277,7 @@ public actual inline val CanPlayTypeResult.Companion.MAYBE: CanPlayTypeResult ge
 public actual inline val CanPlayTypeResult.Companion.PROBABLY: CanPlayTypeResult get() = "probably".toJsString().unsafeCast<CanPlayTypeResult>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface TextTrackMode : JsAny {
     actual companion object
@@ -6290,7 +6290,7 @@ public actual inline val TextTrackMode.Companion.HIDDEN: TextTrackMode get() = "
 public actual inline val TextTrackMode.Companion.SHOWING: TextTrackMode get() = "showing".toJsString().unsafeCast<TextTrackMode>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface TextTrackKind : JsAny {
     actual companion object
@@ -6307,7 +6307,7 @@ public actual inline val TextTrackKind.Companion.CHAPTERS: TextTrackKind get() =
 public actual inline val TextTrackKind.Companion.METADATA: TextTrackKind get() = "metadata".toJsString().unsafeCast<TextTrackKind>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface SelectionMode : JsAny {
     actual companion object
@@ -6322,7 +6322,7 @@ public actual inline val SelectionMode.Companion.END: SelectionMode get() = "end
 public actual inline val SelectionMode.Companion.PRESERVE: SelectionMode get() = "preserve".toJsString().unsafeCast<SelectionMode>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface CanvasFillRule : JsAny {
     actual companion object
@@ -6333,7 +6333,7 @@ public actual inline val CanvasFillRule.Companion.NONZERO: CanvasFillRule get() 
 public actual inline val CanvasFillRule.Companion.EVENODD: CanvasFillRule get() = "evenodd".toJsString().unsafeCast<CanvasFillRule>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface ImageSmoothingQuality : JsAny {
     actual companion object
@@ -6346,7 +6346,7 @@ public actual inline val ImageSmoothingQuality.Companion.MEDIUM: ImageSmoothingQ
 public actual inline val ImageSmoothingQuality.Companion.HIGH: ImageSmoothingQuality get() = "high".toJsString().unsafeCast<ImageSmoothingQuality>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface CanvasLineCap : JsAny {
     actual companion object
@@ -6359,7 +6359,7 @@ public actual inline val CanvasLineCap.Companion.ROUND: CanvasLineCap get() = "r
 public actual inline val CanvasLineCap.Companion.SQUARE: CanvasLineCap get() = "square".toJsString().unsafeCast<CanvasLineCap>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface CanvasLineJoin : JsAny {
     actual companion object
@@ -6372,7 +6372,7 @@ public actual inline val CanvasLineJoin.Companion.BEVEL: CanvasLineJoin get() = 
 public actual inline val CanvasLineJoin.Companion.MITER: CanvasLineJoin get() = "miter".toJsString().unsafeCast<CanvasLineJoin>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface CanvasTextAlign : JsAny {
     actual companion object
@@ -6389,7 +6389,7 @@ public actual inline val CanvasTextAlign.Companion.RIGHT: CanvasTextAlign get() 
 public actual inline val CanvasTextAlign.Companion.CENTER: CanvasTextAlign get() = "center".toJsString().unsafeCast<CanvasTextAlign>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface CanvasTextBaseline : JsAny {
     actual companion object
@@ -6408,7 +6408,7 @@ public actual inline val CanvasTextBaseline.Companion.IDEOGRAPHIC: CanvasTextBas
 public actual inline val CanvasTextBaseline.Companion.BOTTOM: CanvasTextBaseline get() = "bottom".toJsString().unsafeCast<CanvasTextBaseline>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface CanvasDirection : JsAny {
     actual companion object
@@ -6421,7 +6421,7 @@ public actual inline val CanvasDirection.Companion.RTL: CanvasDirection get() = 
 public actual inline val CanvasDirection.Companion.INHERIT: CanvasDirection get() = "inherit".toJsString().unsafeCast<CanvasDirection>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface ScrollRestoration : JsAny {
     actual companion object
@@ -6432,7 +6432,7 @@ public actual inline val ScrollRestoration.Companion.AUTO: ScrollRestoration get
 public actual inline val ScrollRestoration.Companion.MANUAL: ScrollRestoration get() = "manual".toJsString().unsafeCast<ScrollRestoration>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface ImageOrientation : JsAny {
     actual companion object
@@ -6443,7 +6443,7 @@ public actual inline val ImageOrientation.Companion.NONE: ImageOrientation get()
 public actual inline val ImageOrientation.Companion.FLIPY: ImageOrientation get() = "flipY".toJsString().unsafeCast<ImageOrientation>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface PremultiplyAlpha : JsAny {
     actual companion object
@@ -6456,7 +6456,7 @@ public actual inline val PremultiplyAlpha.Companion.PREMULTIPLY: PremultiplyAlph
 public actual inline val PremultiplyAlpha.Companion.DEFAULT: PremultiplyAlpha get() = "default".toJsString().unsafeCast<PremultiplyAlpha>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface ColorSpaceConversion : JsAny {
     actual companion object
@@ -6467,7 +6467,7 @@ public actual inline val ColorSpaceConversion.Companion.NONE: ColorSpaceConversi
 public actual inline val ColorSpaceConversion.Companion.DEFAULT: ColorSpaceConversion get() = "default".toJsString().unsafeCast<ColorSpaceConversion>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface ResizeQuality : JsAny {
     actual companion object
@@ -6482,7 +6482,7 @@ public actual inline val ResizeQuality.Companion.MEDIUM: ResizeQuality get() = "
 public actual inline val ResizeQuality.Companion.HIGH: ResizeQuality get() = "high".toJsString().unsafeCast<ResizeQuality>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface BinaryType : JsAny {
     actual companion object
@@ -6493,7 +6493,7 @@ public actual inline val BinaryType.Companion.BLOB: BinaryType get() = "blob".to
 public actual inline val BinaryType.Companion.ARRAYBUFFER: BinaryType get() = "arraybuffer".toJsString().unsafeCast<BinaryType>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface WorkerType : JsAny {
     actual companion object
@@ -6504,7 +6504,7 @@ public actual inline val WorkerType.Companion.CLASSIC: WorkerType get() = "class
 public actual inline val WorkerType.Companion.MODULE: WorkerType get() = "module".toJsString().unsafeCast<WorkerType>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface ShadowRootMode : JsAny {
     actual companion object
@@ -6515,7 +6515,7 @@ public actual inline val ShadowRootMode.Companion.OPEN: ShadowRootMode get() = "
 public actual inline val ShadowRootMode.Companion.CLOSED: ShadowRootMode get() = "closed".toJsString().unsafeCast<ShadowRootMode>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface ScrollBehavior : JsAny {
     actual companion object
@@ -6528,7 +6528,7 @@ public actual inline val ScrollBehavior.Companion.INSTANT: ScrollBehavior get() 
 public actual inline val ScrollBehavior.Companion.SMOOTH: ScrollBehavior get() = "smooth".toJsString().unsafeCast<ScrollBehavior>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface ScrollLogicalPosition : JsAny {
     actual companion object
@@ -6543,7 +6543,7 @@ public actual inline val ScrollLogicalPosition.Companion.END: ScrollLogicalPosit
 public actual inline val ScrollLogicalPosition.Companion.NEAREST: ScrollLogicalPosition get() = "nearest".toJsString().unsafeCast<ScrollLogicalPosition>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface CSSBoxType : JsAny {
     actual companion object

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.mediacapture.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.mediacapture.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -487,7 +487,7 @@ public actual external interface Constraints : ConstraintSet, JsAny {
 public actual fun Constraints(advanced: JsArray<ConstraintSet>?): Constraints = js("({ advanced: advanced })")
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface MediaStreamTrackState : JsAny {
     actual companion object
@@ -498,7 +498,7 @@ public actual inline val MediaStreamTrackState.Companion.LIVE: MediaStreamTrackS
 public actual inline val MediaStreamTrackState.Companion.ENDED: MediaStreamTrackState get() = "ended".toJsString().unsafeCast<MediaStreamTrackState>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface VideoFacingModeEnum : JsAny {
     actual companion object
@@ -513,7 +513,7 @@ public actual inline val VideoFacingModeEnum.Companion.LEFT: VideoFacingModeEnum
 public actual inline val VideoFacingModeEnum.Companion.RIGHT: VideoFacingModeEnum get() = "right".toJsString().unsafeCast<VideoFacingModeEnum>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface VideoResizeModeEnum : JsAny {
     actual companion object
@@ -524,7 +524,7 @@ public actual inline val VideoResizeModeEnum.Companion.NONE: VideoResizeModeEnum
 public actual inline val VideoResizeModeEnum.Companion.CROP_AND_SCALE: VideoResizeModeEnum get() = "crop-and-scale".toJsString().unsafeCast<VideoResizeModeEnum>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface MediaDeviceKind : JsAny {
     actual companion object

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.mediasource.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.mediasource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -75,7 +75,7 @@ internal fun getMethodImplForSourceBufferList(obj: SourceBufferList, index: Int)
 public actual operator fun SourceBufferList.get(index: Int): SourceBuffer? = getMethodImplForSourceBufferList(this, index)
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface ReadyState : JsAny {
     actual companion object
@@ -88,7 +88,7 @@ public actual inline val ReadyState.Companion.OPEN: ReadyState get() = "open".to
 public actual inline val ReadyState.Companion.ENDED: ReadyState get() = "ended".toJsString().unsafeCast<ReadyState>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface EndOfStreamError : JsAny {
     actual companion object
@@ -99,7 +99,7 @@ public actual inline val EndOfStreamError.Companion.NETWORK: EndOfStreamError ge
 public actual inline val EndOfStreamError.Companion.DECODE: EndOfStreamError get() = "decode".toJsString().unsafeCast<EndOfStreamError>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface AppendMode : JsAny {
     actual companion object

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.parsing.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.parsing.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.pointerevents.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.pointerevents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.svg.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.svg.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.url.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.dom.url.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.fetch.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.fetch.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -149,7 +149,7 @@ public actual external interface ResponseInit : JsAny {
 public actual fun ResponseInit(status: Short?, statusText: String?, headers: JsAny? /* Headers|JsArray<JsArray<JsString>>|OpenEndedDictionary<JsString> */): ResponseInit = js("({ status: status, statusText: statusText, headers: headers })")
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface RequestType : JsAny {
     actual companion object
@@ -172,7 +172,7 @@ public actual inline val RequestType.Companion.TRACK: RequestType get() = "track
 public actual inline val RequestType.Companion.VIDEO: RequestType get() = "video".toJsString().unsafeCast<RequestType>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface RequestDestination : JsAny {
     actual companion object
@@ -209,7 +209,7 @@ public actual inline val RequestDestination.Companion.WORKER: RequestDestination
 public actual inline val RequestDestination.Companion.XSLT: RequestDestination get() = "xslt".toJsString().unsafeCast<RequestDestination>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface RequestMode : JsAny {
     actual companion object
@@ -224,7 +224,7 @@ public actual inline val RequestMode.Companion.NO_CORS: RequestMode get() = "no-
 public actual inline val RequestMode.Companion.CORS: RequestMode get() = "cors".toJsString().unsafeCast<RequestMode>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface RequestCredentials : JsAny {
     actual companion object
@@ -237,7 +237,7 @@ public actual inline val RequestCredentials.Companion.SAME_ORIGIN: RequestCreden
 public actual inline val RequestCredentials.Companion.INCLUDE: RequestCredentials get() = "include".toJsString().unsafeCast<RequestCredentials>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface RequestCache : JsAny {
     actual companion object
@@ -256,7 +256,7 @@ public actual inline val RequestCache.Companion.FORCE_CACHE: RequestCache get() 
 public actual inline val RequestCache.Companion.ONLY_IF_CACHED: RequestCache get() = "only-if-cached".toJsString().unsafeCast<RequestCache>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface RequestRedirect : JsAny {
     actual companion object
@@ -269,7 +269,7 @@ public actual inline val RequestRedirect.Companion.ERROR: RequestRedirect get() 
 public actual inline val RequestRedirect.Companion.MANUAL: RequestRedirect get() = "manual".toJsString().unsafeCast<RequestRedirect>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface ResponseType : JsAny {
     actual companion object

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.files.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.files.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.notifications.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.notifications.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -151,7 +151,7 @@ public actual external interface NotificationEventInit : ExtendableEventInit, Js
 public actual fun NotificationEventInit(notification: Notification?, action: String?, bubbles: Boolean?, cancelable: Boolean?, composed: Boolean?): NotificationEventInit = js("({ notification: notification, action: action, bubbles: bubbles, cancelable: cancelable, composed: composed })")
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface NotificationPermission : JsAny {
     actual companion object
@@ -164,7 +164,7 @@ public actual inline val NotificationPermission.Companion.DENIED: NotificationPe
 public actual inline val NotificationPermission.Companion.GRANTED: NotificationPermission get() = "granted".toJsString().unsafeCast<NotificationPermission>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface NotificationDirection : JsAny {
     actual companion object

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.performance.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.performance.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.workers.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.workers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -397,7 +397,7 @@ public actual external interface UnionMessagePortOrServiceWorker
 public actual external interface UnionClientOrMessagePortOrServiceWorker
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface ServiceWorkerState : JsAny {
     actual companion object
@@ -414,7 +414,7 @@ public actual inline val ServiceWorkerState.Companion.ACTIVATED: ServiceWorkerSt
 public actual inline val ServiceWorkerState.Companion.REDUNDANT: ServiceWorkerState get() = "redundant".toJsString().unsafeCast<ServiceWorkerState>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface FrameType : JsAny {
     actual companion object
@@ -429,7 +429,7 @@ public actual inline val FrameType.Companion.NESTED: FrameType get() = "nested".
 public actual inline val FrameType.Companion.NONE: FrameType get() = "none".toJsString().unsafeCast<FrameType>()
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface ClientType : JsAny {
     actual companion object

--- a/src/wasmJsMain/kotlin/org.w3c/org.w3c.xhr.kt
+++ b/src/wasmJsMain/kotlin/org.w3c/org.w3c.xhr.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -117,7 +117,7 @@ public actual external interface ProgressEventInit : EventInit, JsAny {
 public actual fun ProgressEventInit(lengthComputable: Boolean?, loaded: JsNumber?, total: JsNumber?, bubbles: Boolean?, cancelable: Boolean?, composed: Boolean?): ProgressEventInit = js("({ lengthComputable: lengthComputable, loaded: loaded, total: total, bubbles: bubbles, cancelable: cancelable, composed: composed })")
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public actual external interface XMLHttpRequestResponseType : JsAny {
     actual companion object

--- a/src/webMain/kotlin/org.w3c/org.khronos.webgl.kt
+++ b/src/webMain/kotlin/org.w3c/org.khronos.webgl.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/webMain/kotlin/org.w3c/org.w3c.css.masking.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.css.masking.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/webMain/kotlin/org.w3c/org.w3c.dom.clipboard.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.dom.clipboard.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/webMain/kotlin/org.w3c/org.w3c.dom.css.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.dom.css.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/webMain/kotlin/org.w3c/org.w3c.dom.encryptedmedia.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.dom.encryptedmedia.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -126,7 +126,7 @@ public expect interface MediaEncryptedEventInit : EventInit, JsAny {
 public expect fun MediaEncryptedEventInit(initDataType: String? = "", initData: ArrayBuffer? = null, bubbles: Boolean? = false, cancelable: Boolean? = false, composed: Boolean? = false): MediaEncryptedEventInit
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface MediaKeysRequirement : JsAny {
     companion object
@@ -139,7 +139,7 @@ public expect inline val MediaKeysRequirement.Companion.OPTIONAL: MediaKeysRequi
 public expect inline val MediaKeysRequirement.Companion.NOT_ALLOWED: MediaKeysRequirement
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface MediaKeySessionType : JsAny {
     companion object
@@ -150,7 +150,7 @@ public expect inline val MediaKeySessionType.Companion.TEMPORARY: MediaKeySessio
 public expect inline val MediaKeySessionType.Companion.PERSISTENT_LICENSE: MediaKeySessionType
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface MediaKeyStatus : JsAny {
     companion object
@@ -171,7 +171,7 @@ public expect inline val MediaKeyStatus.Companion.STATUS_PENDING: MediaKeyStatus
 public expect inline val MediaKeyStatus.Companion.INTERNAL_ERROR: MediaKeyStatus
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface MediaKeyMessageType : JsAny {
     companion object

--- a/src/webMain/kotlin/org.w3c/org.w3c.dom.events.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.dom.events.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/webMain/kotlin/org.w3c/org.w3c.dom.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.dom.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -5805,7 +5805,7 @@ public expect interface ImageBitmapSource
 public expect interface HTMLOrSVGScriptElement
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface DocumentReadyState : JsAny {
     companion object
@@ -5818,7 +5818,7 @@ public expect inline val DocumentReadyState.Companion.INTERACTIVE: DocumentReady
 public expect inline val DocumentReadyState.Companion.COMPLETE: DocumentReadyState
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface CanPlayTypeResult : JsAny {
     companion object
@@ -5831,7 +5831,7 @@ public expect inline val CanPlayTypeResult.Companion.MAYBE: CanPlayTypeResult
 public expect inline val CanPlayTypeResult.Companion.PROBABLY: CanPlayTypeResult
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface TextTrackMode : JsAny {
     companion object
@@ -5844,7 +5844,7 @@ public expect inline val TextTrackMode.Companion.HIDDEN: TextTrackMode
 public expect inline val TextTrackMode.Companion.SHOWING: TextTrackMode
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface TextTrackKind : JsAny {
     companion object
@@ -5861,7 +5861,7 @@ public expect inline val TextTrackKind.Companion.CHAPTERS: TextTrackKind
 public expect inline val TextTrackKind.Companion.METADATA: TextTrackKind
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface SelectionMode : JsAny {
     companion object
@@ -5876,7 +5876,7 @@ public expect inline val SelectionMode.Companion.END: SelectionMode
 public expect inline val SelectionMode.Companion.PRESERVE: SelectionMode
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface CanvasFillRule : JsAny {
     companion object
@@ -5887,7 +5887,7 @@ public expect inline val CanvasFillRule.Companion.NONZERO: CanvasFillRule
 public expect inline val CanvasFillRule.Companion.EVENODD: CanvasFillRule
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface ImageSmoothingQuality : JsAny {
     companion object
@@ -5900,7 +5900,7 @@ public expect inline val ImageSmoothingQuality.Companion.MEDIUM: ImageSmoothingQ
 public expect inline val ImageSmoothingQuality.Companion.HIGH: ImageSmoothingQuality
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface CanvasLineCap : JsAny {
     companion object
@@ -5913,7 +5913,7 @@ public expect inline val CanvasLineCap.Companion.ROUND: CanvasLineCap
 public expect inline val CanvasLineCap.Companion.SQUARE: CanvasLineCap
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface CanvasLineJoin : JsAny {
     companion object
@@ -5926,7 +5926,7 @@ public expect inline val CanvasLineJoin.Companion.BEVEL: CanvasLineJoin
 public expect inline val CanvasLineJoin.Companion.MITER: CanvasLineJoin
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface CanvasTextAlign : JsAny {
     companion object
@@ -5943,7 +5943,7 @@ public expect inline val CanvasTextAlign.Companion.RIGHT: CanvasTextAlign
 public expect inline val CanvasTextAlign.Companion.CENTER: CanvasTextAlign
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface CanvasTextBaseline : JsAny {
     companion object
@@ -5962,7 +5962,7 @@ public expect inline val CanvasTextBaseline.Companion.IDEOGRAPHIC: CanvasTextBas
 public expect inline val CanvasTextBaseline.Companion.BOTTOM: CanvasTextBaseline
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface CanvasDirection : JsAny {
     companion object
@@ -5975,7 +5975,7 @@ public expect inline val CanvasDirection.Companion.RTL: CanvasDirection
 public expect inline val CanvasDirection.Companion.INHERIT: CanvasDirection
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface ScrollRestoration : JsAny {
     companion object
@@ -5986,7 +5986,7 @@ public expect inline val ScrollRestoration.Companion.AUTO: ScrollRestoration
 public expect inline val ScrollRestoration.Companion.MANUAL: ScrollRestoration
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface ImageOrientation : JsAny {
     companion object
@@ -5997,7 +5997,7 @@ public expect inline val ImageOrientation.Companion.NONE: ImageOrientation
 public expect inline val ImageOrientation.Companion.FLIPY: ImageOrientation
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface PremultiplyAlpha : JsAny {
     companion object
@@ -6010,7 +6010,7 @@ public expect inline val PremultiplyAlpha.Companion.PREMULTIPLY: PremultiplyAlph
 public expect inline val PremultiplyAlpha.Companion.DEFAULT: PremultiplyAlpha
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface ColorSpaceConversion : JsAny {
     companion object
@@ -6021,7 +6021,7 @@ public expect inline val ColorSpaceConversion.Companion.NONE: ColorSpaceConversi
 public expect inline val ColorSpaceConversion.Companion.DEFAULT: ColorSpaceConversion
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface ResizeQuality : JsAny {
     companion object
@@ -6036,7 +6036,7 @@ public expect inline val ResizeQuality.Companion.MEDIUM: ResizeQuality
 public expect inline val ResizeQuality.Companion.HIGH: ResizeQuality
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface BinaryType : JsAny {
     companion object
@@ -6047,7 +6047,7 @@ public expect inline val BinaryType.Companion.BLOB: BinaryType
 public expect inline val BinaryType.Companion.ARRAYBUFFER: BinaryType
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface WorkerType : JsAny {
     companion object
@@ -6058,7 +6058,7 @@ public expect inline val WorkerType.Companion.CLASSIC: WorkerType
 public expect inline val WorkerType.Companion.MODULE: WorkerType
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface ShadowRootMode : JsAny {
     companion object
@@ -6069,7 +6069,7 @@ public expect inline val ShadowRootMode.Companion.OPEN: ShadowRootMode
 public expect inline val ShadowRootMode.Companion.CLOSED: ShadowRootMode
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface ScrollBehavior : JsAny {
     companion object
@@ -6082,7 +6082,7 @@ public expect inline val ScrollBehavior.Companion.INSTANT: ScrollBehavior
 public expect inline val ScrollBehavior.Companion.SMOOTH: ScrollBehavior
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface ScrollLogicalPosition : JsAny {
     companion object
@@ -6097,7 +6097,7 @@ public expect inline val ScrollLogicalPosition.Companion.END: ScrollLogicalPosit
 public expect inline val ScrollLogicalPosition.Companion.NEAREST: ScrollLogicalPosition
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface CSSBoxType : JsAny {
     companion object

--- a/src/webMain/kotlin/org.w3c/org.w3c.dom.mediacapture.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.dom.mediacapture.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -323,7 +323,7 @@ public expect interface Constraints : ConstraintSet, JsAny {
 public expect fun Constraints(advanced: JsArray<ConstraintSet>? = undefined): Constraints
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface MediaStreamTrackState : JsAny {
     companion object
@@ -334,7 +334,7 @@ public expect inline val MediaStreamTrackState.Companion.LIVE: MediaStreamTrackS
 public expect inline val MediaStreamTrackState.Companion.ENDED: MediaStreamTrackState
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface VideoFacingModeEnum : JsAny {
     companion object
@@ -349,7 +349,7 @@ public expect inline val VideoFacingModeEnum.Companion.LEFT: VideoFacingModeEnum
 public expect inline val VideoFacingModeEnum.Companion.RIGHT: VideoFacingModeEnum
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface VideoResizeModeEnum : JsAny {
     companion object
@@ -360,7 +360,7 @@ public expect inline val VideoResizeModeEnum.Companion.NONE: VideoResizeModeEnum
 public expect inline val VideoResizeModeEnum.Companion.CROP_AND_SCALE: VideoResizeModeEnum
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface MediaDeviceKind : JsAny {
     companion object

--- a/src/webMain/kotlin/org.w3c/org.w3c.dom.mediasource.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.dom.mediasource.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -72,7 +72,7 @@ public expect abstract class SourceBufferList : EventTarget, JsAny {
 public expect operator fun SourceBufferList.get(index: Int): SourceBuffer?
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface ReadyState : JsAny {
     companion object
@@ -85,7 +85,7 @@ public expect inline val ReadyState.Companion.OPEN: ReadyState
 public expect inline val ReadyState.Companion.ENDED: ReadyState
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface EndOfStreamError : JsAny {
     companion object
@@ -96,7 +96,7 @@ public expect inline val EndOfStreamError.Companion.NETWORK: EndOfStreamError
 public expect inline val EndOfStreamError.Companion.DECODE: EndOfStreamError
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface AppendMode : JsAny {
     companion object

--- a/src/webMain/kotlin/org.w3c/org.w3c.dom.parsing.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.dom.parsing.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/webMain/kotlin/org.w3c/org.w3c.dom.pointerevents.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.dom.pointerevents.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/webMain/kotlin/org.w3c/org.w3c.dom.svg.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.dom.svg.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/webMain/kotlin/org.w3c/org.w3c.dom.url.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.dom.url.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/webMain/kotlin/org.w3c/org.w3c.fetch.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.fetch.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -119,7 +119,7 @@ public expect interface ResponseInit : JsAny {
 public expect fun ResponseInit(status: Short? = 200, statusText: String? = "OK", headers: JsAny? /* Headers|JsArray<JsArray<JsString>>|OpenEndedDictionary<JsString> */ = undefined): ResponseInit
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface RequestType : JsAny {
     companion object
@@ -142,7 +142,7 @@ public expect inline val RequestType.Companion.TRACK: RequestType
 public expect inline val RequestType.Companion.VIDEO: RequestType
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface RequestDestination : JsAny {
     companion object
@@ -179,7 +179,7 @@ public expect inline val RequestDestination.Companion.WORKER: RequestDestination
 public expect inline val RequestDestination.Companion.XSLT: RequestDestination
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface RequestMode : JsAny {
     companion object
@@ -194,7 +194,7 @@ public expect inline val RequestMode.Companion.NO_CORS: RequestMode
 public expect inline val RequestMode.Companion.CORS: RequestMode
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface RequestCredentials : JsAny {
     companion object
@@ -207,7 +207,7 @@ public expect inline val RequestCredentials.Companion.SAME_ORIGIN: RequestCreden
 public expect inline val RequestCredentials.Companion.INCLUDE: RequestCredentials
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface RequestCache : JsAny {
     companion object
@@ -226,7 +226,7 @@ public expect inline val RequestCache.Companion.FORCE_CACHE: RequestCache
 public expect inline val RequestCache.Companion.ONLY_IF_CACHED: RequestCache
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface RequestRedirect : JsAny {
     companion object
@@ -239,7 +239,7 @@ public expect inline val RequestRedirect.Companion.ERROR: RequestRedirect
 public expect inline val RequestRedirect.Companion.MANUAL: RequestRedirect
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface ResponseType : JsAny {
     companion object

--- a/src/webMain/kotlin/org.w3c/org.w3c.files.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.files.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/webMain/kotlin/org.w3c/org.w3c.notifications.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.notifications.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -111,7 +111,7 @@ public expect interface NotificationEventInit : ExtendableEventInit, JsAny {
 public expect fun NotificationEventInit(notification: Notification?, action: String? = "", bubbles: Boolean? = false, cancelable: Boolean? = false, composed: Boolean? = false): NotificationEventInit
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface NotificationPermission : JsAny {
     companion object
@@ -124,7 +124,7 @@ public expect inline val NotificationPermission.Companion.DENIED: NotificationPe
 public expect inline val NotificationPermission.Companion.GRANTED: NotificationPermission
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface NotificationDirection : JsAny {
     companion object

--- a/src/webMain/kotlin/org.w3c/org.w3c.performance.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.performance.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 

--- a/src/webMain/kotlin/org.w3c/org.w3c.workers.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.workers.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -343,7 +343,7 @@ public expect interface UnionMessagePortOrServiceWorker
 public expect interface UnionClientOrMessagePortOrServiceWorker
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface ServiceWorkerState : JsAny {
     companion object
@@ -360,7 +360,7 @@ public expect inline val ServiceWorkerState.Companion.ACTIVATED: ServiceWorkerSt
 public expect inline val ServiceWorkerState.Companion.REDUNDANT: ServiceWorkerState
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface FrameType : JsAny {
     companion object
@@ -375,7 +375,7 @@ public expect inline val FrameType.Companion.NESTED: FrameType
 public expect inline val FrameType.Companion.NONE: FrameType
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface ClientType : JsAny {
     companion object

--- a/src/webMain/kotlin/org.w3c/org.w3c.xhr.kt
+++ b/src/webMain/kotlin/org.w3c/org.w3c.xhr.kt
@@ -1,5 +1,5 @@
 /*
- * Copyright 2010-2025 JetBrains s.r.o. and Kotlin Programming Language contributors.
+ * Copyright 2010-2026 JetBrains s.r.o. and Kotlin Programming Language contributors.
  * Use of this source code is governed by the Apache 2.0 license that can be found in the LICENSE file.
  */
 
@@ -111,7 +111,7 @@ public expect interface ProgressEventInit : EventInit, JsAny {
 public expect fun ProgressEventInit(lengthComputable: Boolean? = false, loaded: JsNumber? = 0.toJsNumber(), total: JsNumber? = 0.toJsNumber(), bubbles: Boolean? = false, cancelable: Boolean? = false, composed: Boolean? = false): ProgressEventInit
 
 /* please, don't implement this interface! */
-@JsName("null")
+@JsName("Object")
 @Suppress("NESTED_CLASS_IN_EXTERNAL_INTERFACE")
 public expect interface XMLHttpRequestResponseType : JsAny {
     companion object


### PR DESCRIPTION
see KT-76462 K/Wasm: Redundant `NESTED_CLASS_IN_EXTERNAL_INTERFACE` error